### PR TITLE
Enable Android support by replacing java.rmi.dgc.VMID with java.util.UUID.

### DIFF
--- a/src/cc/mallet/pipe/Pipe.java
+++ b/src/cc/mallet/pipe/Pipe.java
@@ -16,8 +16,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.logging.*;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.UUID;
 import java.io.*;
-import java.rmi.dgc.VMID;
 
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.AlphabetCarrying;
@@ -81,7 +81,7 @@ public abstract class Pipe implements Serializable, AlphabetCarrying
 	boolean targetAlphabetResolved = false;
 	boolean targetProcessing = true;
 
-	VMID instanceId = new VMID();  //used in readResolve to distinguish persistent instances
+	UUID instanceId = UUID.randomUUID();  //used in readResolve to distinguish persistent instances
 
 	/** Construct a pipe with no data and target dictionaries
 	 */
@@ -276,7 +276,7 @@ public abstract class Pipe implements Serializable, AlphabetCarrying
 			targetAlphabet = a;
 	}
 
-	public VMID getInstanceId() { return instanceId;} // for debugging
+	public UUID getInstanceId() { return instanceId;} // for debugging
 	
 	
 	// The InstanceIterator used to implement the one-to-one pipe() method behavior.
@@ -322,10 +322,10 @@ public abstract class Pipe implements Serializable, AlphabetCarrying
 		dataAlphabetResolved = in.readBoolean();
 		targetAlphabetResolved = in.readBoolean();
 		targetProcessing = in.readBoolean();
-		instanceId = (VMID) in.readObject();
+		instanceId = (UUID) in.readObject();
 	}
 
-	private transient static ConcurrentMap<VMID, Object> deserializedEntries = new ConcurrentHashMap<VMID, Object>();
+	private transient static ConcurrentMap<UUID, Object> deserializedEntries = new ConcurrentHashMap<UUID, Object>();
 	
 	/**
 	 * This gets called after readObject; it lets the object decide whether

--- a/src/cc/mallet/types/Alphabet.java
+++ b/src/cc/mallet/types/Alphabet.java
@@ -22,9 +22,9 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.rmi.dgc.VMID;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -54,7 +54,7 @@ public class Alphabet implements Serializable
 	ArrayList entries;
 	volatile boolean growthStopped = false;
 	Class entryClass = null;
-	VMID instanceId = new VMID();  //used in readResolve to identify persitent instances
+	UUID instanceId = UUID.randomUUID();  //used in readResolve to identify persitent instances
 
     private transient ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -323,8 +323,8 @@ public class Alphabet implements Serializable
 		return true;
 	}
 
-	public VMID getInstanceId() { return instanceId;} // for debugging
-	public void setInstanceId(VMID id) { this.instanceId = id; }
+	public UUID getInstanceId() { return instanceId;} // for debugging
+	public void setInstanceId(UUID id) { this.instanceId = id; }
 	// Serialization
 
 	private static final long serialVersionUID = 1;
@@ -361,14 +361,14 @@ public class Alphabet implements Serializable
             growthStopped = in.readBoolean();
             entryClass = (Class) in.readObject();
             if (version > 0) { // instanced id added in version 1S
-                instanceId = (VMID) in.readObject();
+                instanceId = (UUID) in.readObject();
             }
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-	private transient static ConcurrentMap<VMID,Object> deserializedEntries = new ConcurrentHashMap<VMID,Object>();
+	private transient static ConcurrentMap<UUID,Object> deserializedEntries = new ConcurrentHashMap<UUID,Object>();
 
 	/**
 	 * This gets called after readObject; it lets the object decide whether

--- a/src/cc/mallet/types/PagedInstanceList.java
+++ b/src/cc/mallet/types/PagedInstanceList.java
@@ -16,9 +16,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.rmi.dgc.VMID;
 import java.util.BitSet;
 import java.util.Map;
+import java.util.UUID;
 
 import cc.mallet.pipe.Noop;
 import cc.mallet.pipe.Pipe;
@@ -93,7 +93,7 @@ public class PagedInstanceList extends InstanceList
     
     /** uniquely identifies this InstanceList. Used in creating
      * serialized page name for swap files. */
-    VMID id = new VMID();
+    UUID id = UUID.randomUUID();
     
     /** Avoids creating a new noop pipe for each page */
     Pipe noopPipe;
@@ -561,7 +561,7 @@ public class PagedInstanceList extends InstanceList
     }
 
     private void readObject (ObjectInputStream in) throws IOException, ClassNotFoundException {
-        this.id = (VMID) in.readObject ();
+        this.id = (UUID) in.readObject ();
         this.pipe = (Pipe) in.readObject();
         // memory attributes
         this.instancesPerPage = in.readInt ();


### PR DESCRIPTION
Following PR 136 on mimno/Mallet, enable instantiation of your pipeline model on Android devices by replacing uses of java.rmi.dgc.VMID (which isn't present on Android systems) with java.util.UUID.

See https://github.com/mimno/Mallet/pull/136